### PR TITLE
Adds an Assert.Inconclusive() if the CLARIFAI_API_KEY environment variable is not set.

### DIFF
--- a/Clarifai.IntegrationTests/BaseIntTests.cs
+++ b/Clarifai.IntegrationTests/BaseIntTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using Clarifai.API;
+using NUnit.Framework;
 
 namespace Clarifai.IntegrationTests
 {
@@ -29,6 +30,16 @@ namespace Clarifai.IntegrationTests
         private readonly Random _random = new Random(Guid.NewGuid().GetHashCode());
 
         private readonly string _assetsDir = "Assets";
+
+        [SetUp]
+        public void SetUp()
+        {
+            if (string.IsNullOrWhiteSpace(
+                Environment.GetEnvironmentVariable("CLARIFAI_API_KEY")))
+            {
+                Assert.Inconclusive("The CLARIFAI_API_KEY environment variable must be set in order to rum the integration tests.");
+            }
+        }
 
         protected string GenerateRandomID()
         {

--- a/Clarifai.IntegrationTests/BaseIntTests.cs
+++ b/Clarifai.IntegrationTests/BaseIntTests.cs
@@ -37,7 +37,7 @@ namespace Clarifai.IntegrationTests
             if (string.IsNullOrWhiteSpace(
                 Environment.GetEnvironmentVariable("CLARIFAI_API_KEY")))
             {
-                Assert.Inconclusive("The CLARIFAI_API_KEY environment variable must be set in order to rum the integration tests.");
+                Assert.Inconclusive("The CLARIFAI_API_KEY environment variable must be set in order to run the integration tests.");
             }
         }
 


### PR DESCRIPTION
After forking the project and cloning locally, I immediately ran the unit tests. All of the integration tests failed. 

This left me less-than-confident about the state of the "pristine" code base I thought I had. After some poking around, I discovered the reason: I didn't have the CLARIFAI_API_KEY environment variable set.

This PR surfaces that via the test output of Assert.Inconclusive if this is the case.